### PR TITLE
Restacker-Example.yml updates

### DIFF
--- a/docs/02-RESTACKER_YML.md
+++ b/docs/02-RESTACKER_YML.md
@@ -4,25 +4,43 @@ See the sample [here](../source/restacker-example.yml).
 
 ## STRUCTURE
 In order for Restacker to work as expected, the following key:value pairs are required:
-- `:default:`: specifies the default location/plane for all Restacker operations. This is intended to save you from having to specify the required `-l <location>` everytime.
-  - `:label:`: the name of the default location.
-- `:ctrl: &ctrl_default`: default configuration for the Control Account
-  - `:label:`: name of the account
-  - `:role-name:`
-  - `:role-prefix:`
-  - `:bucket:`: S3 Bucket configuration to read/consume files from.
-    - `:name:`: Bucket name
-    - `:prefix:`: **optional** bucket prefix/path
-    - `:ami_key:`: **optional** name of object on S3 that contains list of approved AMIs
-- `:Account_Name:`: name of target account
-  - `:region:`: default region to deploy instances in (e.g. `us-west-2`)
-  - `:ctrl:`: control account for this account
-    - `<<: *ctrl_default`: if the control account is the default account specified in `&ctrl_default`, then just insert default configurations here
-  - `:target:`: the target account configuration
-    - `:label:`: name of target account
-    - `:account_number:`: target account number
-    - `:role_name:`: target role name
-    - `:role_prefix:`: target role prefix
+### GENERAL DEFAULTS
+- `:default:`: This specifies the default location/plane for all Restacker operations. This is intended to save you from having to specify the required `-l <location>` everytime.
+  - `:label:`: Set this to the name of your preferred default location.
+  - `:profile:`: Set this to your preferred default AWS profile (see `~/.aws/credentials`)
+
+### CONTROL PLANE DEFAULTS
+- `:ctrl: &ctrl_default`: This is the default Control-Plane configuration. Do not change this line.
+  - `:label:`: Set this to the name of your control account.
+  - `:role-name:`: Set this to the name of the Control-Plane Role you wish to assume.
+  - `:role-prefix:`: Set this to the prefix of the Control-Plane Role you wish to assume.
+  - `:bucket:`: S3 Bucket configuration to read/consume files from. Do not change this line.
+    - `:name:`: Set this to the S3 bucket name.
+    - `:prefix:`: **optional** Set this to the bucket prefix/path where CloudFormation Templates & approved AMIs are stored.
+    - `:ami_key:`: **optional** Set this to name of the object on S3 that contains list of approved AMIs.
+
+### TARGET PLANE SETTINGS
+- `:acctName:`: This represents the name of the account.
+  - `:region:`: Set this to the default region you wish to operate in.
+  - `:ctrl:`: This represents the control plane for this account. Do not change this line.
+    - `<<: *ctrl_default`: if the control plane configuration for this account is the default account specified above (see `:ctrl: &ctrl_default` section), then just insert default configurations here.
+  - `:target:`: This represents the target plane configuration. Do not change this line.
+    - `:label:`: Set this to the name of the target account.
+    - `:account_number:`: Set this to the target account number.
+    - `:role_name:`: Set this to the target role name you wish to assume.
+    - `:role_prefix:`: Set this to the prefix of the target role you wish to assume.
+
+### NON-CONTROL-PLANE ACCOUNTS (AKA DIRECT ACCOUNTS)
+Not all accounts fall under the Control-Plane architecture. Some accounts are accessible directly without having to assume roles from Control Accounts and Target Accounts, such as testing or learning accounts.
+- `:learn:`: This represents the name of the direct target account
+  - `:region:`: Set this to the region you wish to operate in.
+  - `:profile:`: Set this to the profile name of this account (see `~/.aws/credentials`).
+  - `:target:`: This represents the target account information. Do not change this line.
+    - `:label:`: Set this to the name of your account.
+    - `:account_number:`: Set this to the account number.
+    - `:bucket:`: This represents the S3 bucket settings for the direct target account. Do not change this line.
+      - `:name:`: Set this to the name of the S3 bucket
+      - `:prefix:`: Set this to the bucket prefix where CloudFormation templates are stored.
 
 ## Example Restacker Configuration:
 ```
@@ -67,5 +85,14 @@ In order for Restacker to work as expected, the following key:value pairs are re
     :account_number: '123098456765'
     :role_name: myapp2-dso-DeployAdmin
     :role_prefix: "/dso/human/"
+
+:learn:
+  :region: us-west-2
+  :profile: learning-profile
+  :target:
+    :label: myLearningAccount
+    :account_number: '123456789012'
+    :bucket:
+      :name: my-learning-bucket
 
 ```

--- a/source/restacker-example.yml
+++ b/source/restacker-example.yml
@@ -1,5 +1,6 @@
 :default:
   :label: myapp1
+  :profile: default
 
 :ctrl: &ctrl_default
   :label: ctrlAcct
@@ -39,3 +40,12 @@
     :account_number: '123098456765'
     :role_name: myapp2-dso-DeployAdmin
     :role_prefix: "/dso/human/"
+
+:learn:
+  :region: us-west-2
+  :profile: learn
+  :target:
+    :label: pblearning
+    :account_number: '254175822556'
+    :bucket:
+      :name: pblearning

--- a/source/restacker-example.yml
+++ b/source/restacker-example.yml
@@ -43,9 +43,9 @@
 
 :learn:
   :region: us-west-2
-  :profile: learn
+  :profile: learning-profile
   :target:
-    :label: pblearning
-    :account_number: '254175822556'
+    :label: myLearningAccount
+    :account_number: '123456789012'
     :bucket:
-      :name: pblearning
+      :name: my-learning-bucket


### PR DESCRIPTION
- Renamed `restacker-sample.yml` to `restacker-example.yml`.
- Added `:bucket:` attributes and `:profile:` attributes in `restacker-example.yml` to support non-Control-Plane accounts, such as testing or learning accounts
